### PR TITLE
Manifest upgrades for v0.3.1

### DIFF
--- a/audius/creator-node/creator-node-cm.yaml
+++ b/audius/creator-node/creator-node-cm.yaml
@@ -20,8 +20,10 @@ data:
   ethProviderUrl: "https://mainnet.infura.io/v3/c569c6faf4f14d15a49d0044e7ddd668"
   ethRegistryAddress: "0xb2be26Ca062c5D74964921B80DE6cfa28D9A36c0"
   ethTokenAddress: "0xADEf65C0f6a30Dcb5f88Eb8653BBFe09Bf99864f"
+  headersTimeout: "60000"
   ipfsClusterIP: "<SEE_README>"
   ipfsClusterPort: "<SEE_README>"
+  keepAliveTimeout: "5000"
   logLevel: "debug"
   spOwnerWallet: "<SEE_README>"
 

--- a/audius/creator-node/creator-node-deploy-backend.yaml
+++ b/audius/creator-node/creator-node-deploy-backend.yaml
@@ -12,21 +12,25 @@ spec:
     matchLabels:
       release: creator-node
       tier: backend
+      
   replicas: 1
+  
   template:
     metadata:
       labels:
         release: creator-node
         tier: backend
+        
       annotations:
-        checksum/config: cdbe8757c784b29829734aa48fecc2ad3d43e79697f9ae15ee7d96a98eda7c1e
+        checksum/config: 646d0521edb4535cf8d6a1d89fd3dedbd6226c817be594742973dfa6315a1768
     spec:
+      
       
       containers:
       - name: backend
         imagePullPolicy: Always
         
-        image: audius/creator-node:0.3.0
+        image: audius/creator-node:0.3.1
         
         envFrom:
         - configMapRef:
@@ -47,17 +51,21 @@ spec:
             port: 4000
           initialDelaySeconds: 3
           periodSeconds: 3
+        
         command: ["sh", "-c", "exec node src/index.js"]
+        
         volumeMounts:
         - mountPath: /file_storage
           name: creator-node-backend-pv
           subPath: creator-node-backend
+        
       volumes:
       - name: creator-node-backend-pv
         
         persistentVolumeClaim:
           claimName: creator-node-backend-pvc
         
+      
 
 
 
@@ -81,6 +89,7 @@ spec:
         release: creator-node
         tier: cache
     spec:
+      
       containers:
       - name: creator-node-cache
         image: redis:5.0.5
@@ -102,6 +111,7 @@ spec:
       release: creator-node
       tier: db
   replicas: 1
+  
   template:
     metadata:
       labels:
@@ -110,6 +120,7 @@ spec:
       annotations:
         checksum/config: af1384ab763110e593ca2ef5ba901cc12fd96cccbd9b08511905ed13c981b886
     spec:
+      
       containers:
       - name: creator-node-db
         image: postgres:11.4

--- a/audius/creator-node/creator-node-deploy-ipfs.yaml
+++ b/audius/creator-node/creator-node-deploy-ipfs.yaml
@@ -36,15 +36,19 @@ spec:
     matchLabels:
       release: creator-node
       tier: ipfs
+      
   replicas: 1
+  
   template:
     metadata:
       labels:
         release: creator-node
         tier: ipfs
+        
       annotations:
         checksum/config: a5009ce89593dc1ceef18b84f07a9c0a1994002ca5e6ad8500e54bd74da8bf07
     spec:
+      
       
       containers:
       - name: creator-node-ipfs

--- a/audius/discovery-provider/discovery-provider-cm.yaml
+++ b/audius/discovery-provider/discovery-provider-cm.yaml
@@ -11,6 +11,7 @@ data:
   audius_ipfs_port: "5001"
   
   audius_db_url: "postgresql+psycopg2://postgres:postgres@discovery-provider-db-svc.default.svc.cluster.local:5432/audius_discovery"
+  audius_db_url_read_replica: "postgresql+psycopg2://postgres:postgres@discovery-provider-db-svc.default.svc.cluster.local:5432/audius_discovery"
   
   audius_redis_url: "redis://discovery-provider-cache-svc.default.svc.cluster.local:6379/00"
   audius_contracts_registry: "0xC611C82150b56E6e4Ec5973AcAbA8835Dd0d75A2"
@@ -20,7 +21,7 @@ data:
   audius_discprov_identity_service_url: "https://identityservice.audius.co"
   audius_discprov_start_block: "0xa7cac7f512e8ce7bdeeeaa636b66795ac75ac104ba7d77ef79be9e8d0d7794f3"
   audius_discprov_user_metadata_service_url: "https://usermetadata.audius.co"
-  audius_web3_host: "core.poa.network"
+  audius_web3_host: "poa-gateway.audius.co"
   audius_web3_port: "443"
 
 

--- a/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
@@ -18,13 +18,15 @@ spec:
         release: discovery-provider
         tier: backend
       annotations:
-        checksum/config: bcd9db2e88af8e9161c9b879dd01fff346ef4b321aea0c5d84efddc8475ba98e
+        checksum/config: a420f53694efa8bcbd19f738391c2d4b4da4f90dc4c18c2b952d2afaa0568049
     spec:
+      
+      
       containers:
       - name: server
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:0.3.0
+        image: audius/discovery-provider:0.3.1
         
         envFrom:
         - configMapRef:
@@ -32,7 +34,11 @@ spec:
         
         ports:
         - containerPort: 5000
+        
         command: ["sh", "-c", "./scripts/prod-server.sh"]
+        
+        
+      
 
 
 ---
@@ -55,6 +61,7 @@ spec:
         release: discovery-provider
         tier: cache
     spec:
+      
       containers:
       - name: discovery-provider-cache
         image: redis:5.0.5
@@ -77,6 +84,7 @@ spec:
       release: discovery-provider
       tier: db
   replicas: 1
+  
   template:
     metadata:
       labels:
@@ -117,15 +125,19 @@ spec:
     matchLabels:
       release: discovery-provider
       tier: ipfs
+      
   replicas: 1
+  
   template:
     metadata:
       labels:
         release: discovery-provider
         tier: ipfs
+        
       annotations:
         checksum/config: 2c3c0976bd0ded5df1835e1e093b20769ec8e20378de4be0ef0a85dc50e15730
     spec:
+      
       
       containers:
       - name: discovery-provider-ipfs

--- a/audius/discovery-provider/discovery-provider-deploy.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy.yaml
@@ -18,13 +18,15 @@ spec:
         release: discovery-provider
         tier: backend
       annotations:
-        checksum/config: bcd9db2e88af8e9161c9b879dd01fff346ef4b321aea0c5d84efddc8475ba98e
+        checksum/config: a420f53694efa8bcbd19f738391c2d4b4da4f90dc4c18c2b952d2afaa0568049
     spec:
+      
+      
       containers:
       - name: server
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:0.3.0
+        image: audius/discovery-provider:0.3.1
         
         envFrom:
         - configMapRef:
@@ -32,11 +34,14 @@ spec:
         
         ports:
         - containerPort: 5000
+        
         command: ["sh", "-c", "./scripts/prod-server.sh"]
+        
+        
       - name: worker
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:0.3.0
+        image: audius/discovery-provider:0.3.1
         
         envFrom:
         - configMapRef:
@@ -48,7 +53,7 @@ spec:
       - name: beat
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:0.3.0
+        image: audius/discovery-provider:0.3.1
         
         envFrom:
         - configMapRef:
@@ -57,6 +62,7 @@ spec:
         ports:
         - containerPort: 5000
         command: ["sh", "-c", "celery -A src.worker.celery beat"]
+      
 
 
 ---
@@ -79,6 +85,7 @@ spec:
         release: discovery-provider
         tier: cache
     spec:
+      
       containers:
       - name: discovery-provider-cache
         image: redis:5.0.5
@@ -101,6 +108,7 @@ spec:
       release: discovery-provider
       tier: db
   replicas: 1
+  
   template:
     metadata:
       labels:
@@ -141,15 +149,19 @@ spec:
     matchLabels:
       release: discovery-provider
       tier: ipfs
+      
   replicas: 1
+  
   template:
     metadata:
       labels:
         release: discovery-provider
         tier: ipfs
+        
       annotations:
         checksum/config: 2c3c0976bd0ded5df1835e1e093b20769ec8e20378de4be0ef0a85dc50e15730
     spec:
+      
       
       containers:
       - name: discovery-provider-ipfs

--- a/audius/logger/logger.yaml
+++ b/audius/logger/logger.yaml
@@ -8,6 +8,8 @@ metadata:
   namespace: kube-system
 data:
   source.conf: |
+    
+
     <source>
       tag audius.js.*
       @type tail
@@ -45,10 +47,10 @@ data:
       @type grep
       <regexp>
         key log_level
-        pattern /^(?:error|fatal)$/
+        pattern /^(?:info|warn|error|fatal)$/
       </regexp>
     </filter>
-
+    
     <source>
       tag audius.py.server.*
       @type tail
@@ -114,14 +116,16 @@ data:
       @type grep
       <regexp>
         key log_level
-        pattern /^(?:error|fatal)$/
+        pattern /^(?:info|warn|error|fatal)$/
       </regexp>
     </filter>
 
+    
     <filter audius.**>
       @type kubernetes_metadata
       @id filter_audius_kube_metadata
     </filter>
+    
 
   fluent-loggly.conf: |
     @include source.conf
@@ -177,7 +181,11 @@ subjects:
 ---
 # Source: audius-logger/templates/fluentd-ds.yaml
 
+
+
 apiVersion: apps/v1
+
+
 kind: DaemonSet
 metadata:
   name: fluentd
@@ -186,9 +194,13 @@ metadata:
     app: fluentd
     tier: logs
 spec:
+  
+  # extra selector needed in apps/v1 to support service providers
   selector:
     matchLabels:
       app: fluentd
+  
+    
   template:
     metadata:
       labels:
@@ -201,6 +213,7 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
+      
       - name: fluentd-loggly
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-loggly
         env:
@@ -227,6 +240,8 @@ spec:
         - name: fluentd-cm
           mountPath: /fluentd/etc/fluent.conf
           subPath: fluent-loggly.conf
+      
+      
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog
@@ -238,3 +253,5 @@ spec:
       - name: fluentd-cm
         configMap:
           name: fluentd-cm
+
+

--- a/audius/logger/logger.yaml
+++ b/audius/logger/logger.yaml
@@ -177,7 +177,7 @@ subjects:
 ---
 # Source: audius-logger/templates/fluentd-ds.yaml
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd
@@ -186,6 +186,9 @@ metadata:
     app: fluentd
     tier: logs
 spec:
+  selector:
+    matchLabels:
+      app: fluentd
   template:
     metadata:
       labels:


### PR DESCRIPTION
Noticing some weird behavior trying to get a fresh ubuntu box setup with our kubeadm instructions. The fix:

1. Make sure a folder exists in `/etc/cni/net.d`
2. Place this file called `10-flannel.conflist` inside `/etc/cni/net.d`
```
{
  "name": "cbr0",
  "cniVersion": "0.3.1",
  "plugins": [
    {
      "type": "flannel",
      "delegate": {
        "hairpinMode": true,
        "isDefaultGateway": true
      }
    },
    {
      "type": "portmap",
      "capabilities": {
        "portMappings": true
      }
    }
  ]
}
```
3. Make sure the folder `/run/flannel` exists
4. Place this file called `subnet.env` in `/run/flannel`
```
FLANNEL_NETWORK=10.244.0.0/16
FLANNEL_SUBNET=10.244.0.1/24
FLANNEL_MTU=8951
FLANNEL_IPMASQ=true
```

UPDATE: This doesn't happen if you type the commands one by one. I was running a shell script with all of them, must have been a timing issue