### PR TITLE
Updated Container images for "content-node" and "discovery-node"

### DIFF
--- a/audius/creator-node/creator-node-deploy-backend.yaml
+++ b/audius/creator-node/creator-node-deploy-backend.yaml
@@ -30,7 +30,7 @@ spec:
       - name: backend
         imagePullPolicy: Always
         
-        image: audius/creator-node:6ae1317bc11479f5de7757ea9d1ade00c87ecf5d
+        image: audius/creator-node:e7b2cd20b177d7c2534ca6438f2cd8b37df9f612
         
         envFrom:
         - configMapRef:

--- a/audius/creator-node/creator-node-deploy-ipfs.yaml
+++ b/audius/creator-node/creator-node-deploy-ipfs.yaml
@@ -55,11 +55,12 @@ spec:
         image: ipfs/go-ipfs:v0.4.23
         args: ["daemon", "--migrate=true", "--enable-gc=true"]
         livenessProbe:
-          httpGet:
-            path: /api/v0/id
-            port: 5001
+          exec:
+            command:
+              - ipfs
+              - id
           initialDelaySeconds: 3
-          periodSeconds: 3
+          periodSeconds: 10
         ports:
         - name: swarm
           containerPort: 4001

--- a/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
@@ -26,7 +26,7 @@ spec:
       - name: server
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:6ae1317bc11479f5de7757ea9d1ade00c87ecf5d
+        image: audius/discovery-provider:e7b2cd20b177d7c2534ca6438f2cd8b37df9f612
         
         envFrom:
         - configMapRef:

--- a/audius/discovery-provider/discovery-provider-deploy.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy.yaml
@@ -26,7 +26,7 @@ spec:
       - name: server
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:6ae1317bc11479f5de7757ea9d1ade00c87ecf5d
+        image: audius/discovery-provider:e7b2cd20b177d7c2534ca6438f2cd8b37df9f612
         
         envFrom:
         - configMapRef:
@@ -49,7 +49,7 @@ spec:
       - name: worker
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:6ae1317bc11479f5de7757ea9d1ade00c87ecf5d
+        image: audius/discovery-provider:e7b2cd20b177d7c2534ca6438f2cd8b37df9f612
         
         envFrom:
         - configMapRef:
@@ -61,7 +61,7 @@ spec:
       - name: beat
         imagePullPolicy: Always
         
-        image: audius/discovery-provider:6ae1317bc11479f5de7757ea9d1ade00c87ecf5d
+        image: audius/discovery-provider:e7b2cd20b177d7c2534ca6438f2cd8b37df9f612
         
         envFrom:
         - configMapRef:


### PR DESCRIPTION
Contains container images with service types "content-node" and "discovery-node" as opposed to the old "creator-node" and "discovery-provider"