### PR TITLE
Expand memory size of /dev/shm

### DIFF
--- a/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
@@ -113,10 +113,16 @@ spec:
         - name: discovery-provider-db-pv
           mountPath: /var/lib/postgresql/data
           subPath: discovery-provider-db
+        - name: dshm
+          mountPath: /dev/shm
       volumes:
       - name: discovery-provider-db-pv
         persistentVolumeClaim:
           claimName: discovery-provider-db-pvc
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 1Gi
 
 
 ---

--- a/audius/discovery-provider/discovery-provider-deploy.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy.yaml
@@ -137,10 +137,16 @@ spec:
         - name: discovery-provider-db-pv
           mountPath: /var/lib/postgresql/data
           subPath: discovery-provider-db
+        - name: dshm
+          mountPath: /dev/shm
       volumes:
       - name: discovery-provider-db-pv
         persistentVolumeClaim:
           claimName: discovery-provider-db-pvc
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 1Gi
 
 
 ---


### PR DESCRIPTION
Some db tasks like indexing were failing due to shared memory constraints so this adds more memory to db's running as containers.

https://github.com/AudiusProject/audius-k8s/pull/183