### PR TITLE
Add auto upgrade functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.yaml
+.logs

--- a/audius-cli
+++ b/audius-cli
@@ -150,8 +150,9 @@ def auto_upgrade(cron_expression, remove):
         for job in cron.find_comment("audius-cli auto-upgrade"):
             cron.remove(job)
         if not remove:
+            # Pipe auto upgrade logs to auto_upgrade_logs.txt
             job = cron.new(
-                "bash -c 'yes | audius-cli upgrade'",
+                "date >> auto_upgrade_logs.txt; (bash -c 'yes | /usr/local/bin/audius-cli upgrade' 2>&1) >> auto_upgrade_logs.txt; echo >> auto_upgrade_logs.txt",
                 "audius-cli auto-upgrade",
             )
             job.setall(cron_expression)
@@ -412,25 +413,25 @@ def main():
     )
     subparser.required = True
 
-    # # auto-upgrade subcommand parser
-    # parser_auto_upgrade = subparser.add_parser(
-    #     "auto-upgrade",
-    #     help="Sets up a cron job to auto upgrade services",
-    # )
+    # auto-upgrade subcommand parser
+    parser_auto_upgrade = subparser.add_parser(
+        "auto-upgrade",
+        help="Sets up a cron job to auto upgrade services",
+    )
 
-    # parser_auto_upgrade.add_argument(
-    #     "cron_expression",
-    #     default="0 */6 * * *",
-    #     nargs="?",
-    #     help="Cron expression (default: every 6 hours)",
-    # )
+    parser_auto_upgrade.add_argument(
+        "cron_expression",
+        default="0 */6 * * *",
+        nargs="?",
+        help="Cron expression (default: every 6 hours)",
+    )
 
-    # parser_auto_upgrade.add_argument(
-    #     "-r",
-    #     "--remove",
-    #     action="store_true",
-    #     help="Remove auto-upgrade job",
-    # )
+    parser_auto_upgrade.add_argument(
+        "-r",
+        "--remove",
+        action="store_true",
+        help="Remove auto-upgrade job",
+    )
 
     # check subcommand parser
     parser_check_config = subparser.add_parser(
@@ -559,11 +560,11 @@ def main():
 
     args.manifests_path = os.path.abspath(args.manifests_path)
 
-    # if args.operation == "auto-upgrade":
-    #     auto_upgrade(
-    #         args.cron_expression,
-    #         args.remove,
-    #     )
+    if args.operation == "auto-upgrade":
+        auto_upgrade(
+            args.cron_expression,
+            args.remove,
+        )
     if args.operation == "check-config":
         check_config(
             args.service,

--- a/audius-cli
+++ b/audius-cli
@@ -144,15 +144,22 @@ def _kubectl_wait_seed_job():
     )
 
 
-def auto_upgrade(cron_expression, remove):
+def auto_upgrade(cron_expression, remove, manifests_path):
     """Function to setup a cron job that autoupgrades the node"""
     with CronTab(user=True) as cron:
         for job in cron.find_comment("audius-cli auto-upgrade"):
             cron.remove(job)
         if not remove:
-            # Pipe auto upgrade logs to auto_upgrade_logs.txt
+            # Create {manifests_path}/.logs dir if it does not exist
+            logs_dir_path = os.path.join(manifests_path, '.logs')
+            if not os.path.exists(logs_dir_path):
+                os.makedirs(logs_dir_path)
+                
+            # Pipe auto upgrade logs to {manifests_path}/.logs/auto_upgrade.txt
+            print(f'Setting auto-upgrade cadence [{cron_expression}]')
+            logs_file_path = os.path.join(logs_dir_path, 'auto_upgrade.txt') 
             job = cron.new(
-                "date >> auto_upgrade_logs.txt; (bash -c 'yes | /usr/local/bin/audius-cli upgrade' 2>&1) >> auto_upgrade_logs.txt; echo >> auto_upgrade_logs.txt",
+                f"date >> {logs_file_path}; (bash -c 'yes | /usr/local/bin/audius-cli upgrade' 2>&1) >> {logs_file_path}; echo >> {logs_file_path}",
                 "audius-cli auto-upgrade",
             )
             job.setall(cron_expression)
@@ -564,6 +571,7 @@ def main():
         auto_upgrade(
             args.cron_expression,
             args.remove,
+            args.manifests_path
         )
     if args.operation == "check-config":
         check_config(


### PR DESCRIPTION
This PR is to:
- Uncomment out the audius-cli ability to run auto-upgrades
- Pipe any logs to `{manifests_path}/.logs/auto_upgrade.txt`

Tests:
- Ran `audius-cli autoupgrade "* * * * *"`
- Kept track of the logs to observe behavior at every minute mark

With updates in the latest manifest repo:
```
Mon Apr 12 18:15:01 UTC 2021
Auto-merging audius-cli
Merge made by the 'recursive' strategy.
 README.md                                          | 82 +++++++++++++++-----
 audius-cli                                         | 88 +++++++++++++++++++---
 .../creator-node/creator-node-deploy-backend.yaml  |  2 +-
 .../discovery-provider-deploy-no-workers.yaml      |  4 +-
 .../discovery-provider-deploy.yaml                 |  8 +-
 audius/identity/identity-cm.yaml                   | 31 ++++++++
 audius/identity/identity-deploy.yaml               | 83 ++++++++++++++++++++
 audius/identity/identity-svc.yaml                  | 35 +++++++++
 backup.py                                          |  2 +-
 sp-utilities/claim/claim.js                        |  8 +-
 sp-utilities/discovery-provider/healthChecks.js    | 30 +++++++-
 sp-utilities/package-lock.json                     |  6 +-
 sp-utilities/package.json                          |  2 +-
 13 files changed, 332 insertions(+), 49 deletions(-)
 create mode 100644 audius/identity/identity-cm.yaml
 create mode 100644 audius/identity/identity-deploy.yaml
 create mode 100644 audius/identity/identity-svc.yaml
creator-node-backend-cm has unset keys: discoveryProviderWhitelist
Reverting audius/creator-node/creator-node-cm.yaml
Reverting audius/discovery-provider/discovery-provider-cm.yaml
Pulling changes from source
Updating config maps
Upgrading creator-node...
Do you want to continue? [y/N] service/creator-node-backend-svc unchanged
service/creator-node-cache-svc unchanged
service/creator-node-db-svc unchanged
service/creator-node-ipfs-svc unchanged
persistentvolume/creator-node-backend-pv unchanged
persistentvolumeclaim/creator-node-backend-pvc unchanged
persistentvolume/creator-node-db-pv unchanged
persistentvolumeclaim/creator-node-db-pvc unchanged
persistentvolume/creator-node-ipfs-pv unchanged
persistentvolumeclaim/creator-node-ipfs-pvc unchanged
configmap/creator-node-ipfs-cm unchanged
deployment.apps/creator-node-ipfs unchanged
configmap/creator-node-backend-cm unchanged
configmap/creator-node-db-cm unchanged
deployment.apps/creator-node-backend configured
deployment.apps/creator-node-cache unchanged
deployment.apps/creator-node-db unchanged
```

Without updates in the latest manifest repo:
```
Mon Apr 12 18:16:01 UTC 2021
Already up-to-date.
creator-node-backend-cm has unset keys: discoveryProviderWhitelist
Reverting audius/creator-node/creator-node-cm.yaml
Reverting audius/discovery-provider/discovery-provider-cm.yaml
Reverting audius/identity/identity-cm.yaml
Pulling changes from source
Updating config maps
Upgrading creator-node...
Do you want to continue? [y/N] service/creator-node-backend-svc unchanged
service/creator-node-cache-svc unchanged
service/creator-node-db-svc unchanged
service/creator-node-ipfs-svc unchanged
persistentvolume/creator-node-backend-pv unchanged
persistentvolumeclaim/creator-node-backend-pvc unchanged
persistentvolume/creator-node-db-pv unchanged
persistentvolumeclaim/creator-node-db-pvc unchanged
persistentvolume/creator-node-ipfs-pv unchanged
persistentvolumeclaim/creator-node-ipfs-pvc unchanged
configmap/creator-node-ipfs-cm unchanged
deployment.apps/creator-node-ipfs unchanged
configmap/creator-node-backend-cm unchanged
configmap/creator-node-db-cm unchanged
deployment.apps/creator-node-backend unchanged
deployment.apps/creator-node-cache unchanged
deployment.apps/creator-node-db unchanged
```