### PR TITLE
Set audius_no_workers if using k8s manifests

### DIFF
--- a/audius/discovery-provider/discovery-provider-cm.yaml
+++ b/audius/discovery-provider/discovery-provider-cm.yaml
@@ -30,6 +30,7 @@ data:
   audius_eth_contracts_registry: "0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C"
   audius_gunicorn_worker_class: "eventlet"
   audius_gunicorn_workers: "16"
+  audius_no_workers: "true"
   audius_solana_endpoint: "https://audius.rpcpool.com/4d12c27ad978e40c1b0f8449b93c"
   audius_solana_rewards_manager_account: "71hWFVYokLaN1PNYzTAWi13EfJ7Xt9VbSWUKsXUT8mxE"
   audius_solana_rewards_manager_min_slot: "0"

--- a/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy-no-workers.yaml
@@ -18,7 +18,7 @@ spec:
         release: discovery-provider
         tier: backend
       annotations:
-        checksum/config: 7c9845f17adfa0e4299805a48848a3b382360b712b19d40fc7aeb25430c66caf
+        checksum/config: c7aeeed94f00dd302d1fa11d7c6f648f590f58cf8d1c77e992a576028f1c1269
     spec:
       
       

--- a/audius/discovery-provider/discovery-provider-deploy.yaml
+++ b/audius/discovery-provider/discovery-provider-deploy.yaml
@@ -18,7 +18,7 @@ spec:
         release: discovery-provider
         tier: backend
       annotations:
-        checksum/config: 7c9845f17adfa0e4299805a48848a3b382360b712b19d40fc7aeb25430c66caf
+        checksum/config: c7aeeed94f00dd302d1fa11d7c6f648f590f58cf8d1c77e992a576028f1c1269
     spec:
       
       


### PR DESCRIPTION
It's possible for two sets of workers to come up, one inside the Docker container and one in the k8s deploy. There should be no data issues since we use redis locking and PG constraints to enforce data consistency. However, it does do unnecessary processing, so this turns that off.